### PR TITLE
Do not assume “browser” env, but assume ES6

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -14,6 +14,6 @@ module.exports = {
   },
 
   env: {
-    browser: true
+    es6: true
   }
 };


### PR DESCRIPTION
We want the plugin to be used in Node.js projects for example. But we assume ES6 will be used.