### PR TITLE
Update 'operator-linebreak' rule

### DIFF
--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -55,7 +55,7 @@ module.exports = {
   'no-void': 2,
   'object-curly-spacing': [2, 'never'],
   'object-shorthand': 2,
-  'operator-linebreak': [2, 'before'],
+  'operator-linebreak': [2, 'after'],
   'padded-blocks': 0,
   'prefer-arrow-callback': 2,
   'prefer-const': 2,


### PR DESCRIPTION
Update `operator-linebreak` rule to replace `before` by `after`.

We are doing this so `prettier` and `eslint` play nice together regarding `operators`.